### PR TITLE
Update branch for Dimbreath's repository to master

### DIFF
--- a/api.md
+++ b/api.md
@@ -106,7 +106,7 @@ As outlined in [UID endpoints](#uid-endpoints), when you make a UID request, you
 ### playerInfo
 
 For basic data of characters by ID, go to [store/characters.json](https://github.com/EnkaNetwork/API-docs/blob/master/store/characters.json).  <br />
-For any additional info, check the [Characters Data](https://gitlab.com/Dimbreath/AnimeGameData/-/blob/main/ExcelBinOutput/AvatarExcelConfigData.json).
+For any additional info, check the [Characters Data](https://gitlab.com/Dimbreath/AnimeGameData/-/blob/master/ExcelBinOutput/AvatarExcelConfigData.json).
 
 | Name | Description |
 | :--- | :--------- | 
@@ -132,7 +132,7 @@ For any additional info, check the [Characters Data](https://gitlab.com/Dimbreat
 ### avatarInfoList
 
 For basic data of characters by ID, go to [store/characters.json](https://github.com/EnkaNetwork/API-docs/blob/master/store/characters.json).  <br />
-For any additional info, check the [Characters Data](https://gitlab.com/Dimbreath/AnimeGameData/-/blob/main/ExcelBinOutput/AvatarExcelConfigData.json).
+For any additional info, check the [Characters Data](https://gitlab.com/Dimbreath/AnimeGameData/-/blob/master/ExcelBinOutput/AvatarExcelConfigData.json).
 
 | Name | Description                                                                                                                                                                               |
 | :--- |:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -140,9 +140,9 @@ For any additional info, check the [Characters Data](https://gitlab.com/Dimbreat
 | talentIdList | List of Constellation IDs <br /> There is no data if 0 Constellation                                                                                                                      |
 | [propMap](#propmap) | Character Info Properties List                                                                                                                                                            |
 | fightPropMap -> `{id: value}` | Map of Character's Combat Properties. <br />Check the [Definitions for IDs](#fightprop)                                                                                                   |
-| skillDepotId | Character Skill Set ID <br />[Skills Data](https://gitlab.com/Dimbreath/AnimeGameData/-/blob/main/ExcelBinOutput/AvatarSkillDepotExcelConfigData.json) ->     `"id"`                      |
-| inherentProudSkillList | List of Unlocked Skill Ids <br />[Skills Data](https://gitlab.com/Dimbreath/AnimeGameData/-/blob/main/ExcelBinOutput/AvatarSkillDepotExcelConfigData.json) -> `"inherentProudSkillOpens"` | 
-| skillLevelMap -> `{skill_id: level}`| Map of Skill Levels <br /> [Skills Data](https://gitlab.com/Dimbreath/AnimeGameData/-/blob/main/ExcelBinOutput/AvatarSkillDepotExcelConfigData.json) -> `"inherentProudSkillOpens"`     |
+| skillDepotId | Character Skill Set ID <br />[Skills Data](https://gitlab.com/Dimbreath/AnimeGameData/-/blob/master/ExcelBinOutput/AvatarSkillDepotExcelConfigData.json) ->     `"id"`                      |
+| inherentProudSkillList | List of Unlocked Skill Ids <br />[Skills Data](https://gitlab.com/Dimbreath/AnimeGameData/-/blob/master/ExcelBinOutput/AvatarSkillDepotExcelConfigData.json) -> `"inherentProudSkillOpens"` | 
+| skillLevelMap -> `{skill_id: level}`| Map of Skill Levels <br /> [Skills Data](https://gitlab.com/Dimbreath/AnimeGameData/-/blob/master/ExcelBinOutput/AvatarSkillDepotExcelConfigData.json) -> `"inherentProudSkillOpens"`     |
 | [equipList](#equiplist) | List of Equipments: Weapon, Ariftacts                                                                                                                                                     |
 | fetterInfo.expLevel  | Character Friendship Level                                                                                                                                                                |
 
@@ -158,14 +158,14 @@ For any additional info, check the [Characters Data](https://gitlab.com/Dimbreat
 
 | Name | Description |
 | :--- | :--------- |
-| itemId | Equipment ID <br /> [Artifacts Data](https://gitlab.com/Dimbreath/AnimeGameData/-/blob/main/ExcelBinOutput/ReliquaryExcelConfigData.json) -> `"id"` <br /> [Weapons Data](https://gitlab.com/Dimbreath/AnimeGameData/-/blob/main/ExcelBinOutput/WeaponExcelConfigData.json) -> `"id"` |
+| itemId | Equipment ID <br /> [Artifacts Data](https://gitlab.com/Dimbreath/AnimeGameData/-/blob/master/ExcelBinOutput/ReliquaryExcelConfigData.json) -> `"id"` <br /> [Weapons Data](https://gitlab.com/Dimbreath/AnimeGameData/-/blob/master/ExcelBinOutput/WeaponExcelConfigData.json) -> `"id"` |
 | [weapon](#weapon) `[Weapon Only]` | Weapon Base Info  |
 | [reliquary](#reliquary) `[Artifact Only]` | Artifact Base Info  |
 | [flat](#flat) | Detailed Info of Equipment |
 
 #### weapon
 
-For any additional info about weapons, check the [Weapons Data](https://gitlab.com/Dimbreath/AnimeGameData/-/blob/main/ExcelBinOutput/WeaponExcelConfigData.json)
+For any additional info about weapons, check the [Weapons Data](https://gitlab.com/Dimbreath/AnimeGameData/-/blob/master/ExcelBinOutput/WeaponExcelConfigData.json)
 
 | Name | Description |
 | :--- | :---------- |
@@ -176,13 +176,13 @@ For any additional info about weapons, check the [Weapons Data](https://gitlab.c
 
 #### reliquary
 
-For any additional info about artifacts, check the [Artifacts Data](https://gitlab.com/Dimbreath/AnimeGameData/-/blob/main/ExcelBinOutput/ReliquaryExcelConfigData.json)
+For any additional info about artifacts, check the [Artifacts Data](https://gitlab.com/Dimbreath/AnimeGameData/-/blob/master/ExcelBinOutput/ReliquaryExcelConfigData.json)
 
 | Name | Description |
 | :--- | :---------- |
 | level | Artifact Level `[1-21]` |
-| mainPropId | Artifact Main Stat ID <br /> [MainProps Data](https://gitlab.com/Dimbreath/AnimeGameData/-/blob/main/ExcelBinOutput/ReliquaryMainPropExcelConfigData.json) |
-| appendPropIdList | List of IDs of the artifact substats <br /> [AppendProp Data](https://gitlab.com/Dimbreath/AnimeGameData/-/blob/main/ExcelBinOutput/ReliquaryAffixExcelConfigData.json) |
+| mainPropId | Artifact Main Stat ID <br /> [MainProps Data](https://gitlab.com/Dimbreath/AnimeGameData/-/blob/master/ExcelBinOutput/ReliquaryMainPropExcelConfigData.json) |
+| appendPropIdList | List of IDs of the artifact substats <br /> [AppendProp Data](https://gitlab.com/Dimbreath/AnimeGameData/-/blob/master/ExcelBinOutput/ReliquaryAffixExcelConfigData.json) |
 
 #### flat
 


### PR DESCRIPTION
(gitlab.com/Dimbreath/AnimeGameData)[https://gitlab.com/Dimbreath/AnimeGameData] changed their default branch from `main` to `master`. The docs still used `main`. This PR fixes that.