### PR TITLE
New fields and typo 

### DIFF
--- a/api.md
+++ b/api.md
@@ -252,13 +252,15 @@ For any additional info about artifacts, check the [Artifacts Data](https://gitl
 | 54 | Anemo RES                                         |
 | 55 | Geo RES                                           |
 | 56 | Cryo RES                                          |
-| 70 | Pyro Enegry Cost                                  |
+| 70 | Pyro Energy Cost                                  |
 | 71 | Electro Energy Cost                               |
 | 72 | Hydro Energy Cost                                 |
 | 73 | Dendro Energy Cost                                |
 | 74 | Anemo Energy Cost                                 |
 | 75 | Cryo Energy Cost                                  |
 | 76 | Geo Energy Cost                                   |
+| 77 | Fighting Spirit Limit                             |
+| 78 | Fighting Spirit required for Ultimate             | 
 | 80 | Cooldown reduction                                |
 | 81 | Shield Strength                                   |
 | 1000 | Current Pyro Energy                               |


### PR DESCRIPTION
This PR fixes a typo with "Pyro Enegry" and adds the new fields.
After digging into some api responses, the 77 and 78 only appear on Mavuika and are not there on the other Natlan characters. Future characters that use the same mechanic that Mavuika has to charge her ultimate may require this field to be changed, given that 78 exists. (Also the other languages don't have these fields yet).

This PR is highly experimental as I know nothing about the fields and only took a few minutes of research. If Algo manages to get the list again like when the docs came out feel free to correct this PR. 

77 = Fighting Spirit Limit?
78 = Fighting Spirit required for Ultimate (since Mavuika can use her ultimate when she has 50% of 77)?